### PR TITLE
Fix "No repository field" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "playback": "~0.2.0",
     "user-home": "~2.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cheeaun/kyoku"
+  },
   "devDependencies": {
     "electron-packager": "~5.1.0",
     "electron-prebuilt": "0.34.0"


### PR DESCRIPTION
Fixes the following message:

<img width="558" alt="screen shot 2015-10-30 at 2 47 11 pm" src="https://cloud.githubusercontent.com/assets/432489/10856339/1f1dd89c-7f15-11e5-8714-90169d22cc2c.png">
