### PR TITLE
Support displaying song title from a radio station

### DIFF
--- a/itunes.js
+++ b/itunes.js
@@ -12,7 +12,7 @@ var Itunes = function(){
     + 'var itunes = Application("iTunes");'
     + 'var currentTrack = itunes.currentTrack();'
     + 'JSON.stringify({'
-      + 'name: currentTrack.name(),'
+      + 'name: itunes.currentStreamTitle() || currentTrack.name(),'
       + 'artist: currentTrack.artist(),'
       + 'album: currentTrack.album(),'
       + 'playing: itunes.playerState() == "playing"'


### PR DESCRIPTION
When listening to a radio station, in original version, Kyoku would only display the station’s name with no indication of current playing track.

This patch patches Kyoku to display the station’s playing song.

<img width="431" alt="screen shot 2016-07-08 at 3 36 14 pm" src="https://cloud.githubusercontent.com/assets/193136/16681922/cd5742fe-4521-11e6-899c-a9d4aa6a5e46.png">
